### PR TITLE
Updated Gitpod link with referral tracking

### DIFF
--- a/week3-AppDev-crud/README.MD
+++ b/week3-AppDev-crud/README.MD
@@ -117,7 +117,7 @@ You can click the **Launch Now** link at the bottom of "Connection Details" box 
 
 ## 3. Connectivity to Cassandra 
 
-**✅ Step 3a Open gitpod** : [Gitpod](https://www.gitpod.io/) is an IDE 100% online based on Eclipse Theia. To initialize your environment simply click on the button below *(CTRL + Click to open in new tab)*
+**✅ Step 3a Open gitpod** : [Gitpod](http://www.gitpod.io/?utm_source=datastax&utm_medium=referral&utm_campaign=datastaxworkshops) is an IDE 100% online based on Eclipse Theia. To initialize your environment simply click on the button below *(CTRL + Click to open in new tab)*
 
 [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/DataStax-Academy/cassandra-workshop-series)
 


### PR DESCRIPTION
Added DataStax as the referral source in the Gitpod link so Typefox can track the traffic coming from our workshops.