### PR TITLE
week4, Fix Swagger allow to select file for /api/credentials

### DIFF
--- a/week4-AppDev-api/getting-started-with-astra-java/src/main/java/com/datastax/astra/controller/CredentialsController.java
+++ b/week4-AppDev-api/getting-started-with-astra-java/src/main/java/com/datastax/astra/controller/CredentialsController.java
@@ -63,12 +63,12 @@ public class CredentialsController {
             @ApiResponse(code = 400, message = "Invalid or missing parameters"),
             @ApiResponse(code = 500, message = "Internal error - cannot save file")
     })
-    @ApiImplicitParams({
-        @ApiImplicitParam(
-            name = "file",
-            value = "A binary zip file provided by astra to initiate a 2-ways SSL connection",
-            required = true, dataType = "file", paramType = "form")
-    })
+    //@ApiImplicitParams({
+    //    @ApiImplicitParam(
+    //        name = "file",
+    //        value = "A binary zip file provided by astra to initiate a 2-ways SSL connection",
+    //        required = true, dataType = "file", paramType = "form")
+    //})
     public ResponseEntity<String> saveCredentials(
         @RequestParam("username") 
         @ApiParam(name="username", value="login for user authentication", required=true)


### PR DESCRIPTION
comment out @ApiImplicitParams for `/api/credentials`
Reason: Swagger displays textbox instead of allowing to browse to select file

[Discord discussion](https://discord.com/channels/685554030159593522/685560345418530821/737284619308892250)