### PR TITLE
"Fixing" active flag status to match what the Java version is doing

### DIFF
--- a/week4-AppDev-api/getting-started-with-astra-python/controller/spacecraft_journey_controller.py
+++ b/week4-AppDev-api/getting-started-with-astra-python/controller/spacecraft_journey_controller.py
@@ -26,7 +26,7 @@ def journeys_for_spacecraft(spacecraft_name):
         journey_id = min_uuid_from_time(now)
         start = now
         end = now + timedelta(seconds=1000)
-        active = True
+        active = False
         summary = request.get_data(as_text=True)
 
         astra_service.create_new_journey_for_spacecraft(spacecraft_name, journey_id, start, end, active, summary)


### PR DESCRIPTION
The backend API doesn't allow an update to an existing spacecraft journey so the active status looks like it never completes in the python version. The java version simply sets this to "false" right out of the gate. Setting this value to "false" in the python version to match the java experience.

I've tested this change up on gitpod and now see the same experience as the java version.